### PR TITLE
minor documentation fix - missing space on line 37 of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ the generated HTML will be in the `out` directory.
 You can use any web server to check it out in your browser:
 ```
 cd out
-python3 -mhttp.server
+python3 -m http.server
 ```
 
 ## Development


### PR DESCRIPTION
I came across this repository and noticed the typo. This is the proposed fix. Here's to hoping that this PR is accepted!

Thank you, 
Anirudh Rowjee