### PR TITLE
Fix codify tera filter

### DIFF
--- a/src/page_gen/filters.rs
+++ b/src/page_gen/filters.rs
@@ -3,7 +3,7 @@ use regex::{Captures, Regex};
 use std::collections::HashMap;
 use tera::{self, Value};
 
-static RE_CODIFY: Lazy<Regex> = Lazy::new(|| Regex::new(r"\&#96;(.+?)\&#96;").unwrap());
+static RE_CODIFY: Lazy<Regex> = Lazy::new(|| Regex::new(r"`(.+?)`").unwrap());
 
 pub fn codify(value: &Value, _: &HashMap<String, Value>) -> tera::Result<Value> {
     let value = match value {

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,7 +1,7 @@
 {%- macro render_items(items) %}
   {%- for item in items | reverse %}
     <li>
-      {{ item.title | codify }}
+      {{ item.title | escape | codify | safe }}
       {%- if item.unresolved %}
         <a class="unresolved"
           href="{{ item.unresolved.url }}"
@@ -9,7 +9,7 @@
         {%- continue %}
       {%- endif %}
       {%- if item.link %}
-        <a href="{{ item.link.url }}">{{ item.link.text | codify }}</a>
+        <a href="{{ item.link.url }}">{{ item.link.text | escape | codify | safe }}</a>
         {%- continue %}
       {%- endif %}
       {%- if not item.stabilized %}
@@ -68,6 +68,6 @@
   <li>
     <a class="{{ class }}"
         href="{{ issue.number | issue_url }}"
-        title="{{ issue.title }}">#{{ issue.number }} - {{ issue.title | codify }}</a>
+        title="{{ issue.title }}">#{{ issue.number }} - {{ issue.title | escape | codify | safe }}</a>
   </li>
 {%- endmacro %}


### PR DESCRIPTION
codify stopped working in f90db52, due to various changes to how tera handles escaped values.

This fixes it by updating the regular expression to correctly recognize backtick characters, and then changing the order of escaping operations so that the code tag gets through to the final result.

**Note:** I believe the filter could also be rewritten with [`is_safe`](https://docs.rs/tera/latest/tera/trait.Filter.html#method.is_safe), but I find the explicit `escape | codify | safe` to make it more clear what's going on.